### PR TITLE
Introduce TES type of service

### DIFF
--- a/service-info/ga4gh-service-info.json
+++ b/service-info/ga4gh-service-info.json
@@ -34,5 +34,11 @@
       "group": "org.ga4gh",
       "artifact": "drs"
     }
+  },
+  {
+    "type": {
+      "group": "org.ga4gh",
+      "artifact": "tes"
+    }
   }
 ]


### PR DESCRIPTION
[TES](https://github.com/ga4gh/task-execution-schemas) from the Cloud Workstream is currently in the process of preparing for approval of the version 1.0.0 (the first release).
One of the required steps is to introduce `service-info` (which has been done in the proposed spec) and - similarly to the remaining Cloud Workstream specifications, I would like to request a new service info type for TES.