### PR TITLE
add ga4gh-search specification to service info type register

### DIFF
--- a/service-info/ga4gh-service-info.json
+++ b/service-info/ga4gh-service-info.json
@@ -14,7 +14,7 @@
   {
     "type": {
       "group": "org.ga4gh",
-      "artifact": "ga4gh-search"
+      "artifact": "search"
     }
   },
   {

--- a/service-info/ga4gh-service-info.json
+++ b/service-info/ga4gh-service-info.json
@@ -14,6 +14,12 @@
   {
     "type": {
       "group": "org.ga4gh",
+      "artifact": "ga4gh-search"
+    }
+  },
+  {
+    "type": {
+      "group": "org.ga4gh",
       "artifact": "rnaget"
     }
   },


### PR DESCRIPTION
this PR aims to add the canonical `ga4gh-search` artifact value to the GA4GH service info type registry

@mcupak 