### PR TITLE
Alphabetise the service-info registry entries [trivial editorial]

### DIFF
--- a/service-info/README.md
+++ b/service-info/README.md
@@ -37,7 +37,7 @@ Additional items can be raised as required for standards. It is recommended that
 To add an item to this list, please take the following steps.
 <ol>
 <li>Create a fork of the TASC repo in your own user space</li>
-<li>Modify the JSON file with the values for your PR</li>
+<li>Modify the JSON file with the values for your PR, keeping the entries ordered alphabetically</li>
 <li>Submit the changes as a PR back into the TASC repository</li>
 <li>Notify the GA4GH Secretariat or TASC Force directly</li>
 <li>The GA4GH TASC Force will review and either approve or comment. Please respond to comments to allow the process to move forwards.</li>

--- a/service-info/ga4gh-service-info.json
+++ b/service-info/ga4gh-service-info.json
@@ -8,25 +8,7 @@
   {
     "type": {
       "group": "org.ga4gh",
-      "artifact": "service-registry"
-    }
-  },
-  {
-    "type": {
-      "group": "org.ga4gh",
-      "artifact": "rnaget"
-    }
-  },
-  {
-    "type": {
-      "group": "org.ga4gh",
-      "artifact": "wes"
-    }
-  },
-  {
-    "type": {
-      "group": "org.ga4gh",
-      "artifact": "trs"
+      "artifact": "data-connect"
     }
   },
   {
@@ -38,13 +20,31 @@
   {
     "type": {
       "group": "org.ga4gh",
+      "artifact": "rnaget"
+    }
+  },
+  {
+    "type": {
+      "group": "org.ga4gh",
+      "artifact": "service-registry"
+    }
+  },
+  {
+    "type": {
+      "group": "org.ga4gh",
       "artifact": "tes"
     }
   },
   {
     "type": {
       "group": "org.ga4gh",
-      "artifact": "data-connect"
+      "artifact": "trs"
+    }
+  },
+  {
+    "type": {
+      "group": "org.ga4gh",
+      "artifact": "wes"
     }
   }
 ]


### PR DESCRIPTION
For ease of reference, and so that there is a canonical form for the list and a unique place for each new addition, keep the service-info registry entries in alphabetical order.