### PR TITLE
Add Data Connect standard to service info registry

### DIFF
--- a/service-info/ga4gh-service-info.json
+++ b/service-info/ga4gh-service-info.json
@@ -40,5 +40,11 @@
       "group": "org.ga4gh",
       "artifact": "tes"
     }
+  },
+  {
+    "type": {
+      "group": "org.ga4gh",
+      "artifact": "data-connect"
+    }
   }
 ]


### PR DESCRIPTION
With GA4GH Search having been recently rebranded and approved, this PR should supersede #23.