### PR TITLE
replace Craig with Jonathan as the DURI rep to TASC

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ TASC consists of at least 1 volunteer representative from each Work Stream from 
 | Marc Fiume       | Discovery            |
 | James Eddy       | Cloud                |
 | John Marshall    | Large Scale Genomics |
-| Craig Voisin     | DURI                 |
+| Jonathan Lawson  | DURI                 |
 | Bob Freimuth     | GKS                  |
 | Francesca Frexia | Clin/Pheno           |
 | David Bernick    | Security             |


### PR DESCRIPTION
should have done this a while ago, this PR replaces Craig with Jonathan as the TASC member from DURI on our README