### PR TITLE
Fix JSON syntax in README's example [truly trivial editorial]

### DIFF
--- a/service-info/README.md
+++ b/service-info/README.md
@@ -13,18 +13,18 @@ To enable servers using the suite of GA4GH APIs to be used in a networks, the Se
 ### JSON format
 
 The JSON file shall feature entries in the following format:
-```
+```json
 [
   {
     "type": {
       "group": "org.ga4gh",
-      "artifact": "first-api-name",
+      "artifact": "first-api-name"
     }
   },
   {
     "type": {
       "group": "org.ga4gh",
-      "artifact": "other-api-name",
+      "artifact": "other-api-name"
     }
   }
 ]


### PR DESCRIPTION
Another small one: a minor correction that really could just be merged unilaterally by @jb-adams or @mamanambiya:

Fix JSON syntax (no trailing commas) in the README's example, and annotate the code block so it is colourised as JSON.