### PR TITLE
Add htsget to service-info registry

### DIFF
--- a/service-info/ga4gh-service-info.json
+++ b/service-info/ga4gh-service-info.json
@@ -20,6 +20,12 @@
   {
     "type": {
       "group": "org.ga4gh",
+      "artifact": "htsget"
+    }
+  },
+  {
+    "type": {
+      "group": "org.ga4gh",
       "artifact": "rnaget"
     }
   },


### PR DESCRIPTION
[Htsget](https://www.ga4gh.org/genomic-data-toolkit/#htsget-API-V1.0.0) (which was approved as a [GA4GH standard in 2017](https://twitter.com/GA4GH/status/920318023873024002); see also [this later thread](https://twitter.com/GA4GH/status/1010180085796786176) and [associated GA4GH news article](https://www.ga4gh.org/news/-9msBlhISDK_ltjA7Vt6aA.article)) recently implemented service-info in PR samtools/hts-specs#493.

See the [htsget specification's service-info section](https://samtools.github.io/hts-specs/htsget.html#ga4gh-service-info) and the corresponding part of the [htsget OpenAPI protocol description](https://samtools.github.io/hts-specs/pub/htsget-openapi.yaml) (search the latter for `htsgetServiceInfo`).

This PR adds the `artifact` value used to TASC's registry.