### PR TITLE
Update service-info artifact list to add refget

### DIFF
--- a/service-info/ga4gh-service-info.json
+++ b/service-info/ga4gh-service-info.json
@@ -26,6 +26,12 @@
   {
     "type": {
       "group": "org.ga4gh",
+      "artifact": "refget"
+    }
+  },
+  {
+    "type": {
+      "group": "org.ga4gh",
       "artifact": "rnaget"
     }
   },


### PR DESCRIPTION
[Refget](https://github.com/samtools/hts-specs/blob/master/refget.md) currently in v1.0.1 does not support the standard service info specification.
Support is being added in [v2.0](https://github.com/samtools/hts-specs/blob/8c5ea91a997046642b80b2c184dddf2e3d22ec32/refget.md#method-fetch-information-on-the-service) via [this PR](https://github.com/samtools/hts-specs/pull/479/files#diff-6d0ee984bc484773c3af9e49b390168a371979e396e2de4887bff1ee1791c3ae).

This proposal adds the required artifact value used to TASC's registry. 