### PR TITLE
Update service info artifact list to add seqcol and rename refget

### DIFF
--- a/service-info/ga4gh-service-info.json
+++ b/service-info/ga4gh-service-info.json
@@ -26,13 +26,13 @@
   {
     "type": {
       "group": "org.ga4gh",
-      "artifact": "refget.sequence"
+      "artifact": "refget.seqcol"
     }
   },
   {
     "type": {
       "group": "org.ga4gh",
-      "artifact": "refget.seqcol"
+      "artifact": "refget.sequence"
     }
   },
   {

--- a/service-info/ga4gh-service-info.json
+++ b/service-info/ga4gh-service-info.json
@@ -26,13 +26,13 @@
   {
     "type": {
       "group": "org.ga4gh",
-      "artifact": "refget.seqcol"
+      "artifact": "refget-seqcol"
     }
   },
   {
     "type": {
       "group": "org.ga4gh",
-      "artifact": "refget.sequence"
+      "artifact": "refget-sequence"
     }
   },
   {

--- a/service-info/ga4gh-service-info.json
+++ b/service-info/ga4gh-service-info.json
@@ -26,7 +26,13 @@
   {
     "type": {
       "group": "org.ga4gh",
-      "artifact": "refget"
+      "artifact": "refget.sequence"
+    }
+  },
+  {
+    "type": {
+      "group": "org.ga4gh",
+      "artifact": "refget.seqcol"
     }
   },
   {


### PR DESCRIPTION
The [sequence collection specification](https://seqcol.readthedocs.io/en/latest/specification/) is currently ongoing GA4GH product approval and as part of this process we're proposing to add a new type to the TASC registry.

The development of the sequence collection specification also saw the rebranding of refget as a more generic term encompassing both refget.sequence (previously refget) and refget.seqcol (for sequence collection)



