### PR TITLE
Record decision date separately from record date on ADRs

### DIFF
--- a/adr/template.md
+++ b/adr/template.md
@@ -1,6 +1,6 @@
 # TASC-ADR-XXX: [Short Decision Title]
 
-**Date:** YYYY-MM-DD | **Status:** [Proposed | Accepted | Deprecated | Superseded]  
+**Decided:** [when the decision was taken, e.g. a meeting or workshop] | **Recorded:** YYYY-MM-DD | **Status:** [Proposed | Accepted | Deprecated | Superseded]  
 
 **Deciders:** [List key decision-makers]  
 **Keywords:** [e.g., maturity-model, versioning, governance, api, security]  

--- a/governance/TASC_Document_Standards.md
+++ b/governance/TASC_Document_Standards.md
@@ -97,7 +97,7 @@ All ADRs MUST include the following metadata header and follow the Nygard templa
 ```markdown
 # TASC-ADR-XXX: [Short Decision Title]
 
-**Date:** YYYY-MM-DD | **Status:** [Proposed | Accepted | Deprecated | Superseded]  
+**Decided:** [when the decision was taken, e.g. a meeting or workshop] | **Recorded:** YYYY-MM-DD | **Status:** [Proposed | Accepted | Deprecated | Superseded]  
 **Deciders:** [List key decision-makers]  
 **Keywords:** [comma-separated keywords]  
 **Work Streams Impacted:** [affected work streams]  
@@ -116,6 +116,8 @@ All ADRs MUST include the following metadata header and follow the Nygard templa
 | **Raised by** | The person and work stream/role that originally raised the issue (recommendations only) |
 | **Authors** | Those who wrote the document |
 | **Deciders** | Those who made the decision (ADRs only) |
+| **Decided** | The date the decision was taken, e.g. at a meeting or workshop (ADRs only) |
+| **Recorded** | The date the ADR document was written (ADRs only) |
 | **Keywords** | Searchable tags for discoverability (e.g., api, pagination, governance, maturity-model) |
 | **Work Streams Impacted** | GA4GH work streams affected by the document |
 | **Products Affected** | Specific GA4GH products impacted |


### PR DESCRIPTION
## Summary

Distinguish, on every GA4GH ADR, **when the decision was taken** from **when the record was written**. An ADR previously carried a single `Date:` field, which conflated the two — for example a decision taken at a workshop but written up weeks later.

## Changes

- **`adr/template.md`** — the metadata line becomes `**Decided:** … | **Recorded:** YYYY-MM-DD | **Status:** …`.
- **`governance/TASC_Document_Standards.md` (TASC-GOV-02)** — the same split in the ADR metadata header block, plus two rows in the Metadata Field Definitions table defining **Decided** and **Recorded** (ADRs only).

Recommendations and governance documents keep their single `Date:` field (they are living documents); this change applies to ADRs only.

## Notes

Existing ADRs (TASC-ADR-001–005) are unchanged here. Backporting the split to them is a follow-up, once their decision dates are confirmed.
